### PR TITLE
Add Dependabot updates and CI quality gates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "deps(actions)"
+
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "deps(pip)"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "deps(npm)"

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -105,6 +105,12 @@ jobs:
           print("Secret hygiene scan passed.")
           PY
 
+      - name: Backend lint
+        run: python -m ruff check backend
+
+      - name: Backend type check
+        run: python -m mypy --config-file backend/mypy.ini
+
       - name: Wait for PostgreSQL
         run: |
           for i in {1..40}; do
@@ -117,8 +123,8 @@ jobs:
       - name: Backend unit tests
         run: python -m pytest backend/tests/test_intelligence_fusion_service.py -q
 
-      - name: Backend full suite
-        run: python -m pytest backend/tests -q
+      - name: Backend full suite with coverage gate
+        run: python -m pytest backend/tests -q --cov=backend --cov-report=term-missing --cov-fail-under=70
 
       - name: Frontend tests
         run: npm run test:frontend

--- a/backend/intelligence_fusion_service.py
+++ b/backend/intelligence_fusion_service.py
@@ -26,12 +26,14 @@ from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, ValidationErro
 
 try:
     from asyncio_mqtt import Client as MQTTClient
-    from asyncio_mqtt import MqttError
+    from asyncio_mqtt import MqttError as AsyncIOMqttError
 except Exception:  # pragma: no cover - optional dependency during local scaffolding
     MQTTClient = None
 
-    class MqttError(Exception):
+    class AsyncIOMqttError(Exception):  # type: ignore[no-redef]
         pass
+
+MqttError = AsyncIOMqttError
 
 
 logger = logging.getLogger("shakti.intelligence_fusion")

--- a/backend/mypy.ini
+++ b/backend/mypy.ini
@@ -1,0 +1,8 @@
+[mypy]
+python_version = 3.11
+files = backend/intelligence_fusion_service.py
+ignore_missing_imports = True
+warn_unused_ignores = True
+warn_redundant_casts = True
+warn_return_any = False
+strict_optional = True

--- a/backend/requirements-ci.txt
+++ b/backend/requirements-ci.txt
@@ -2,7 +2,10 @@ anyio==4.12.1
 asyncpg==0.31.0
 fastapi==0.135.1
 httpx==0.28.1
+mypy==1.18.2
 pydantic==2.12.5
 pytest==9.0.2
 pytest-asyncio==1.3.0
+pytest-cov==7.0.0
+ruff==0.14.6
 starlette==0.52.1


### PR DESCRIPTION
Implements roadmap steps 3 and 4:\n- Add weekly Dependabot updates for GitHub Actions, pip, and npm\n- Add backend lint gate (ruff)\n- Add backend type-check gate (mypy)\n- Add backend coverage threshold gate (pytest-cov fail-under=70)\n\nAlso includes a mypy-safe optional MQTT import alias fix in backend service.